### PR TITLE
Add `check-cert` for checking a host's TLS cert.

### DIFF
--- a/bin/check-cert
+++ b/bin/check-cert
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+usage() {
+	name=$(basename "$0")
+
+	cat <<-EOT
+	${name} [hostname]
+
+	Show the TLS/SSL certificate behind a host.
+
+	Options:
+	  -h/--help Show this help.
+	EOT
+	exit 1
+}
+
+if [ "$#" -lt 1 ]; then
+	usage;
+	exit 1;
+fi
+
+main() {
+	curl --insecure -v "https://$1" 2>&1 | awk \
+		'BEGIN { cert=0 } /^\* SSL connection/ { cert=1 } /^\*/ { if (cert) print }'
+}
+
+main "$@"


### PR DESCRIPTION
E.g.:

```
$ check-cert nickcharlton.net
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=nickcharlton.net
*  start date: Jan  3 22:56:03 2018 GMT
*  expire date: Apr  3 22:56:03 2018 GMT
*  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
*  SSL certificate verify ok.
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after
upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fc685000000)
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
* Connection #0 to host nickcharlton.net left intact
```